### PR TITLE
Bonus implementation for SCC25

### DIFF
--- a/closed/NVIDIA/start_triton.sh
+++ b/closed/NVIDIA/start_triton.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+MODEL_REPO=/path/to/repo_0 #created by triton config builds
+TRITON_BIN=/opt/tritonserver/bin/tritonserver
+GRPC_PORT=8001
+HTTP_PORT=8000
+METRICS_PORT=8002
+
+WORLD_SIZE= #number of GPUs per node
+
+exec mpirun -n ${WORLD_SIZE} --allow-run-as-root \
+  ${TRITON_BIN} \
+    --model-repository=${MODEL_REPO} \
+    --grpc-port=${GRPC_PORT} \
+    --http-port=${HTTP_PORT} \
+    --metrics-port=${METRICS_PORT}


### PR DESCRIPTION
This PR introduces the necessary scripts and documentation to enable multi-node execution for the NVIDIA implementation of the Llama2-70B MLPerf Inference benchmark.

The added materials detail configuration, startup instructions, and node-to-node communication setup required for distributed inference across multiple H100 nodes.

✅ PR Checklist – Previous Submission Round repo (v5.0)
This repository contains finalized and published results for a previous submission round. Before submitting changes, please confirm the following:

🔒 Safeguard Against Accidental Disclosure
[ ✅ ] I confirm that I am not committing results or system updates intended for a future round.
[ ✅ ] This PR does not contain any result, metadata, or logs for an unreleased submission round.
🛠️ Valid Post-Publication Changes (if any)
[✅ ] This PR does not alter the published accuracy, latency, or system identity of any prior result.
📄 PR Communication
[✅ ] I have clearly explained the reason for this change in the PR description.